### PR TITLE
chore: replace the fonts to use fonts-croscore

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,5 +24,5 @@ Depends: ${misc:Depends}, ${python3:Depends},
  gir1.2-gdkpixbuf-2.0,
  gir1.2-pango-1.0,
  ffmpeg (>= 7:2.5.0),
- ttf-mscorefonts-installer
+ fonts-croscore
 Description: Render BigBlueButton recording events.xml to a video


### PR DESCRIPTION
Replacing `ttf-mscorefonts-installer` with `fonts-croscore` to avoid EULA prompts. The replacement pick was suggested by @kepstin 
Note: This PR is a draft because it's not tested yet.