### PR TITLE
Fix some errors in processing Text and Arrow shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ events.xml
 presentation-video
 presentation
 __pycache__
+.venv

--- a/bbb_presentation_video/events/tldraw.py
+++ b/bbb_presentation_video/events/tldraw.py
@@ -21,6 +21,7 @@ class StyleData(TypedDict, total=False):
 
 
 class ShapeData(TypedDict, total=False):
+    bend: float
     childIndex: float
     isComplete: bool
     label: str

--- a/bbb_presentation_video/renderer/tldraw/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/__init__.py
@@ -148,6 +148,8 @@ class TldrawRenderer:
             del self.shapes[presentation][slide][id]
         except KeyError:
             return
+        except ValueError:
+            return
         self.shapes_changed = True
         print(
             f"\tTldraw: deleted shape: {id}, presentation: {presentation}, slide: {slide}"

--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -28,6 +28,13 @@ class BaseShape:
     point: Position
     """Position of the origin of the shape."""
 
+    def __init__(self, data: ShapeData) -> None:
+        self.style = Style()
+        self.childIndex = 1
+        self.point = Position(0, 0)
+
+        self.update_from_data(data)
+
     def update_from_data(self, data: ShapeData) -> None:
         self.data = data
 
@@ -36,14 +43,8 @@ class BaseShape:
         if "childIndex" in data:
             self.childIndex = data["childIndex"]
         if "point" in data:
-            self.point = Position(*data["point"])
-
-    @classmethod
-    def from_data(cls: Type[BaseShapeSelf], data: ShapeData) -> BaseShapeSelf:
-        shape = cls.__new__(cls)
-        shape.update_from_data(data)
-        return shape
-
+            point = data["point"]
+            self.point = Position(point[0], point[1])
 
 class RotatableShapeProto(Protocol):
     """The size and rotation fields that are common to many shapes."""
@@ -55,8 +56,6 @@ class RotatableShapeProto(Protocol):
         """Update the common size and rotation fields."""
         if "size" in data:
             self.size = Size(*data["size"])
-        else:
-            self.size = Size(0, 0)
         if "rotation" in data:
             self.rotation = data["rotation"]
 
@@ -82,11 +81,22 @@ def shape_sort_key(shape: BaseShape) -> float:
 class DrawShape(BaseShape):
     points: DrawPoints
     isComplete: bool
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
     cached_bounds: Optional[Bounds] = None
     cached_path: Optional[cairo.Path] = None
     cached_outline_path: Optional[cairo.Path] = None
+
+    def __init__(self, data: ShapeData) -> None:
+        self.points = []
+        self.isComplete = False
+        self.size = Size(0, 0)
+        self.rotation = 0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -110,12 +120,24 @@ class DrawShape(BaseShape):
 
 @define
 class RectangleShape(BaseShape):
+    # LabelledShapeProto
     label: Optional[str]
     labelPoint: Position
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
     cached_path: Optional[cairo.Path] = None
     cached_outline_path: Optional[cairo.Path] = None
+
+    def __init__(self, data: ShapeData) -> None:
+        self.label = None
+        self.labelPoint = Position(0.5, 0.5)
+        self.size = Size(1, 1)
+        self.rotation = 0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -130,12 +152,26 @@ class RectangleShape(BaseShape):
 @define
 class EllipseShape(BaseShape):
     radius: Tuple[float, float]
+
+    # LabelledShapeProto
     label: Optional[str]
     labelPoint: Position
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
     cached_path: Optional[cairo.Path] = None
     cached_outline_path: Optional[cairo.Path] = None
+
+    def __init__(self, data: ShapeData) -> None:
+        self.radius = (1.0, 1.0)
+        self.label = None
+        self.labelPoint = Position(0.5, 0.5)
+        self.size = Size(1.0, 1.0)
+        self.rotation = 0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -153,12 +189,24 @@ class EllipseShape(BaseShape):
 
 @define
 class TriangleShape(BaseShape):
+    # LabelledShapeProto
     label: Optional[str]
     labelPoint: Position
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
     cached_path: Optional[cairo.Path] = None
     cached_outline_path: Optional[cairo.Path] = None
+
+    def __init__(self, data: ShapeData) -> None:
+        self.label = None
+        self.labelPoint = Position(0.5, 0.5)
+        self.size = Size(1.0, 1.0)
+        self.rotation = 0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -173,8 +221,17 @@ class TriangleShape(BaseShape):
 @define
 class TextShape(BaseShape):
     text: str
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
+    def __init__(self, data: ShapeData) -> None:
+        self.text = ""
+        self.size = Size(0.0, 0.0)
+        self.rotation = 0.0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -190,14 +247,25 @@ class GroupShape(BaseShape):
     # children: List[str]
     # size: Size
     # rotation: float
-    pass
+    
+    def __init__(self, data: ShapeData) -> None:
+        super().__init__(data)
 
 
 @define
 class StickyShape(BaseShape):
     text: str
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
+    def __init__(self, data: ShapeData) -> None:
+        self.text = ""
+        self.size = Size(200.0, 200.0)
+        self.rotation = 0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -219,21 +287,44 @@ class ArrowHandles:
     end: ArrowHandle
     bend: ArrowHandle
 
+    def __init__(self):
+        # TODO: This is temporary so arrows don't crash the app. Needs to be replaced with proper parsing.
+        self.start = ArrowHandle(Position(0, 0))
+        self.end = ArrowHandle(Position(0, 0))
+        self.bend = ArrowHandle(Position(0, 0))
+
 
 @define
 class ArrowShape(BaseShape):
-    label: Optional[str]
-    labelPoint: Position
     bend: float
     handles: ArrowHandles
+
+    # LabelledShapeProto
+    label: Optional[str]
+    labelPoint: Position
+
+    # RotatableShapeProto
     size: Size
     rotation: float
+
+    def __init__(self, data: ShapeData) -> None:
+        self.bend = 0.0
+        self.handles = ArrowHandles()
+        self.label = None,
+        self.labelPoint = Position(0.5, 0.5)
+        self.size = Size(0.0, 0.0)
+        self.rotation = 0.0
+
+        super().__init__(data)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
 
         if "bend" in data:
             self.bend = data["bend"]
+        
+        # TODO: parse this from data
+        self.handles = ArrowHandles()
 
         LabelledShapeProto.update_from_data(self, data)
         RotatableShapeProto.update_from_data(self, data)
@@ -254,21 +345,21 @@ Shape = Union[
 def parse_shape_from_data(data: ShapeData) -> Shape:
     type = data["type"]
     if type == "draw":
-        return DrawShape.from_data(data)
+        return DrawShape(data)
     elif type == "rectangle":
-        return RectangleShape.from_data(data)
+        return RectangleShape(data)
     elif type == "ellipse":
-        return EllipseShape.from_data(data)
+        return EllipseShape(data)
     elif type == "triangle":
-        return TriangleShape.from_data(data)
+        return TriangleShape(data)
     elif type == "arrow":
-        return ArrowShape.from_data(data)
+        return ArrowShape(data)
     elif type == "text":
-        return TextShape.from_data(data)
+        return TextShape(data)
     elif type == "group":
-        return GroupShape.from_data(data)
+        return GroupShape(data)
     elif type == "sticky":
-        return StickyShape.from_data(data)
+        return StickyShape(data)
     else:
         raise Exception(f"Unknown shape type: {type}")
 

--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -55,6 +55,8 @@ class RotatableShapeProto(Protocol):
         """Update the common size and rotation fields."""
         if "size" in data:
             self.size = Size(*data["size"])
+        else:
+            self.size = Size(0, 0)
         if "rotation" in data:
             self.rotation = data["rotation"]
 
@@ -182,9 +184,6 @@ class TextShape(BaseShape):
 
         RotatableShapeProto.update_from_data(self, data)
 
-        self.cached_path = None
-        self.cached_outline_path = None
-
 
 @define
 class GroupShape(BaseShape):
@@ -233,6 +232,10 @@ class ArrowShape(BaseShape):
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
 
+        if "bend" in data:
+            self.bend = data["bend"]
+
+        LabelledShapeProto.update_from_data(self, data)
         RotatableShapeProto.update_from_data(self, data)
 
 

--- a/bbb_presentation_video/renderer/tldraw/shape/text.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/text.py
@@ -50,8 +50,10 @@ def finalize_text(ctx: cairo.Context, id: str, shape: TextShape) -> None:
     layout = Pango.Layout(pctx)
     layout.set_auto_dir(True)
     layout.set_font_description(font)
-    layout.set_width(int(shape.size.width * Pango.SCALE))
-    layout.set_height(int(shape.size.height * Pango.SCALE))
+    if shape.size.width > 0:
+        layout.set_width(int(shape.size.width * Pango.SCALE))
+    if shape.size.height > 0:
+        layout.set_height(int(shape.size.height * Pango.SCALE))
     layout.set_wrap(Pango.WrapMode.WORD_CHAR)
     if style.textAlign == AlignStyle.START:
         layout.set_alignment(Pango.Alignment.LEFT)
@@ -84,8 +86,10 @@ def finalize_label(ctx: cairo.Context, shape: LabelledShapeProto) -> None:
     layout = Pango.Layout(pctx)
     layout.set_auto_dir(True)
     layout.set_font_description(font)
-    layout.set_width(int(shape.size.width * Pango.SCALE))
-    layout.set_height(int(shape.size.height * Pango.SCALE))
+    if shape.size.width > 0:
+        layout.set_width(int(shape.size.width * Pango.SCALE))
+    if shape.size.height > 0:
+        layout.set_height(int(shape.size.height * Pango.SCALE))
     layout.set_wrap(Pango.WrapMode.WORD_CHAR)
     layout.set_alignment(Pango.Alignment.CENTER)
 

--- a/bbb_presentation_video/renderer/tldraw/utils.py
+++ b/bbb_presentation_video/renderer/tldraw/utils.py
@@ -103,8 +103,8 @@ class DashStyle(Enum):
 class FontStyle(Enum):
     SCRIPT: str = "script"
     SANS: str = "sans"
-    ERIF: str = "erif"  # SIC
-    SERIF: str = "serif"  # In case they fix the spelling
+    ERIF: str = "erif"  # Old tldraw versions had this spelling mistake
+    SERIF: str = "serif"
     MONO: str = "mono"
 
 
@@ -136,19 +136,23 @@ class Style:
 
     @classmethod
     def from_data(cls, data: StyleData) -> "Style":
-        font = FontStyle(data["font"]) if "font" in data else FontStyle.SCRIPT
-        textAlign = (
-            AlignStyle(data["textAlign"]) if "textAlign" in data else AlignStyle.MIDDLE
-        )
-        return Style(
-            color=ColorStyle(data["color"]),
-            size=SizeStyle(data["size"]),
-            dash=DashStyle(data["dash"]),
-            isFilled=data["isFilled"],
-            scale=data["scale"],
-            font=font,
-            textAlign=textAlign,
-        )
+        style = Style()
+        if "color" in data:
+            style.color = ColorStyle(data["color"])
+        if "size" in data:
+            style.size = SizeStyle(data["size"])
+        if "dash" in data:
+            style.dash = DashStyle(data["dash"])
+        if "isFilled" in data:
+            style.isFilled = data["isFilled"]
+        if "scale" in data:
+            style.scale = data["scale"]
+        if "font" in data:
+            style.font = FontStyle(data["font"])
+        if "textAlign" in data:
+            style.textAlign = AlignStyle(data["textAlign"])
+        
+        return style
 
 
 def get_bounds_from_points(

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-bbb-presentation-video (4.0.0) UNRELEASED; urgency=medium
+bbb-presentation-video (4.0.0~beta1) focal; urgency=medium
 
-  * Add support for tldraw whiteboard
+  * Initial support for tldraw whiteboard
 
  -- Calvin Walton <calvin.walton@blindsidenetworks.com>  Tue, 04 Oct 2022 16:25:28 -0400
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,5 @@ files = "."
 mypy_path = "$MYPY_CONFIG_FILE_DIR/typings"
 
 [[tool.mypy.overrides]]
-module = "cattrs"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "sortedcollections"
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = bbb-presentation-video
-version = 4.0.0
+version = 4.0.0-beta.1
 description = Render BigBlueButton recording events.xml file to a video
 author = BigBlueButton Inc.
 url = https://github.com/bigbluebutton/bbb-presentation-video


### PR DESCRIPTION
The "size" field might not always be sent on the first update of a text shape, so ensure it gets initialized (I use 0, 0 here to indicate undetermined size; special handling is added so that this results in no word wrapping being performed.

The text shape parsing was attempting to update some attributs related to cached paths, but this shape doesn't use cached paths. Drop that.

Add a few attributes that the arrow shapes were missing. It's far from complete, currently hitting an arrow still crashes rendering.