### PR TITLE
Fix compatibility with attrs 19.3.0

### DIFF
--- a/bbb_presentation_video/events/__init__.py
+++ b/bbb_presentation_video/events/__init__.py
@@ -8,7 +8,7 @@ from enum import Enum
 from fractions import Fraction
 from typing import Any, Deque, List, Optional, Tuple, TypedDict, cast
 
-from attrs import define
+import attr
 from lxml import etree
 from packaging.version import Version
 
@@ -26,7 +26,7 @@ MAGIC_MYSTERY_NUMBER = 2.0
 DEFAULT_PRESENTATION_POD = "DEFAULT_PRESENTATION_POD"
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Size:
     width: float
     height: float

--- a/bbb_presentation_video/events/helpers.py
+++ b/bbb_presentation_video/events/helpers.py
@@ -4,7 +4,7 @@
 
 from typing import Iterator, Optional, Type, TypeVar
 
-from attrs import define
+import attr
 from lxml import etree
 
 from bbb_presentation_video.events.errors import EventParsingError
@@ -12,7 +12,7 @@ from bbb_presentation_video.events.errors import EventParsingError
 _ColorSelf = TypeVar("_ColorSelf", bound="Color")
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Color:
     r: float
     g: float
@@ -46,7 +46,7 @@ def color_blend(a: Color, b: Color, t: float) -> Color:
     )
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Position:
     x: float
     y: float

--- a/bbb_presentation_video/renderer/cursor.py
+++ b/bbb_presentation_video/renderer/cursor.py
@@ -5,8 +5,8 @@
 from math import pi, sqrt
 from typing import Dict, Optional
 
+import attr
 import cairo
-from attrs import define
 
 from bbb_presentation_video.events import (
     CursorEvent,
@@ -42,7 +42,7 @@ def apply_legacy_cursor_transform(ctx: cairo.Context, t: Transform) -> None:
     ctx.clip()
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Cursor:
     label: Optional[str]
     position: Optional[Position] = None

--- a/bbb_presentation_video/renderer/presentation.py
+++ b/bbb_presentation_video/renderer/presentation.py
@@ -9,9 +9,9 @@ from typing import Dict, Optional, Union
 from urllib.parse import quote as urlquote
 from urllib.parse import urlunsplit
 
+import attr
 import cairo
 import gi
-from attrs import define
 from pkg_resources import resource_filename
 
 gi.require_version("Gdk", "3.0")
@@ -50,7 +50,7 @@ LOGO_TYPE = ImageType.PDF
 DRAWING_SIZE = 1200
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Transform(object):
     padding: Size
     scale: float

--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -4,8 +4,8 @@
 
 from typing import List, Optional, Protocol, Tuple, Type, TypeVar, Union
 
+import attr
 import cairo
-from attrs import define
 
 from bbb_presentation_video.events import Size
 from bbb_presentation_video.events.helpers import Position
@@ -15,7 +15,7 @@ from bbb_presentation_video.renderer.tldraw.utils import Bounds, DrawPoints, Sty
 BaseShapeSelf = TypeVar("BaseShapeSelf", bound="BaseShape")
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class BaseShape:
     """The base class for all tldraw shapes."""
 
@@ -45,6 +45,7 @@ class BaseShape:
         if "point" in data:
             point = data["point"]
             self.point = Position(point[0], point[1])
+
 
 class RotatableShapeProto(Protocol):
     """The size and rotation fields that are common to many shapes."""
@@ -77,7 +78,7 @@ def shape_sort_key(shape: BaseShape) -> float:
     return shape.childIndex
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class DrawShape(BaseShape):
     points: DrawPoints
     isComplete: bool
@@ -118,7 +119,7 @@ class DrawShape(BaseShape):
         self.cached_outline_path = None
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class RectangleShape(BaseShape):
     # LabelledShapeProto
     label: Optional[str]
@@ -149,7 +150,7 @@ class RectangleShape(BaseShape):
         self.cached_outline_path = None
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class EllipseShape(BaseShape):
     radius: Tuple[float, float]
 
@@ -187,7 +188,7 @@ class EllipseShape(BaseShape):
         self.cached_outline_path = None
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class TriangleShape(BaseShape):
     # LabelledShapeProto
     label: Optional[str]
@@ -218,7 +219,7 @@ class TriangleShape(BaseShape):
         self.cached_outline_path = None
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class TextShape(BaseShape):
     text: str
 
@@ -242,17 +243,17 @@ class TextShape(BaseShape):
         RotatableShapeProto.update_from_data(self, data)
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class GroupShape(BaseShape):
     # children: List[str]
     # size: Size
     # rotation: float
-    
+
     def __init__(self, data: ShapeData) -> None:
         super().__init__(data)
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class StickyShape(BaseShape):
     text: str
 
@@ -276,12 +277,12 @@ class StickyShape(BaseShape):
         RotatableShapeProto.update_from_data(self, data)
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class ArrowHandle:
     point: Position
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class ArrowHandles:
     start: ArrowHandle
     end: ArrowHandle
@@ -294,7 +295,7 @@ class ArrowHandles:
         self.bend = ArrowHandle(Position(0, 0))
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class ArrowShape(BaseShape):
     bend: float
     handles: ArrowHandles
@@ -310,7 +311,7 @@ class ArrowShape(BaseShape):
     def __init__(self, data: ShapeData) -> None:
         self.bend = 0.0
         self.handles = ArrowHandles()
-        self.label = None,
+        self.label = (None,)
         self.labelPoint = Position(0.5, 0.5)
         self.size = Size(0.0, 0.0)
         self.rotation = 0.0
@@ -322,7 +323,7 @@ class ArrowShape(BaseShape):
 
         if "bend" in data:
             self.bend = data["bend"]
-        
+
         # TODO: parse this from data
         self.handles = ArrowHandles()
 

--- a/bbb_presentation_video/renderer/tldraw/shape/arrow.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/arrow.py
@@ -6,7 +6,7 @@ from math import hypot
 from typing import Tuple
 
 import cairo
-from attrs import astuple
+from attr import astuple
 
 from bbb_presentation_video.renderer.tldraw import vec
 from bbb_presentation_video.renderer.tldraw.shape import ArrowShape

--- a/bbb_presentation_video/renderer/tldraw/utils.py
+++ b/bbb_presentation_video/renderer/tldraw/utils.py
@@ -6,19 +6,18 @@ from enum import Enum
 from math import floor, inf, pi, sqrt
 from typing import Dict, List, Sequence, Tuple, Union
 
+import attr
 import cairo
 import perfect_freehand
-from attrs import define
 
 from bbb_presentation_video.events.helpers import Color, color_blend
 from bbb_presentation_video.events.tldraw import StyleData
 from bbb_presentation_video.renderer.tldraw import vec
 
-
 DrawPoints = List[Union[Tuple[float, float], Tuple[float, float, float]]]
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Bounds:
     min_x: float
     min_y: float
@@ -124,7 +123,7 @@ class AlignStyle(Enum):
     JUSTIFY: str = "justify"
 
 
-@define
+@attr.s(order=False, slots=True, auto_attribs=True)
 class Style:
     color: ColorStyle = ColorStyle.BLACK
     size: SizeStyle = SizeStyle.SMALL
@@ -151,7 +150,7 @@ class Style:
             style.font = FontStyle(data["font"])
         if "textAlign" in data:
             style.textAlign = AlignStyle(data["textAlign"])
-        
+
         return style
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bbb-presentation-video (4.0.0~beta2) focal; urgency=medium
+
+  * Make compatible with attrs version 19.3.0
+
+ -- Calvin Walton <calvin.walton@blindsidenetworks.com>  Thu, 26 Jan 2023 13:53:23 -0500
+
 bbb-presentation-video (4.0.0~beta1) focal; urgency=medium
 
   * Initial support for tldraw whiteboard

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Install requires (keep in sync with setup.cfg)
-attrs
+attrs == 19.3.0 # Ensure we use APIs that work on Ubuntu 20.04
 lxml
 packaging
 pycairo

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = bbb-presentation-video
-version = 4.0.0-beta.1
+version = 4.0.0-beta.2
 description = Render BigBlueButton recording events.xml file to a video
 author = BigBlueButton Inc.
 url = https://github.com/bigbluebutton/bbb-presentation-video

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    attrs
+    attrs >= 19.3.0
     lxml
     packaging
     pycairo


### PR DESCRIPTION
We're using the Ubuntu packaged `python3-attr` which ships an old version of attrs that doesn't support the new-style API. Adjust the code to be compatible with the older attrs version.