### PR TITLE
fix(tldraw): use deepmerge to handle shape data update

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -10,7 +10,7 @@ import cairo
 from bbb_presentation_video.events import Size
 from bbb_presentation_video.events.helpers import Position
 from bbb_presentation_video.events.tldraw import ShapeData
-from bbb_presentation_video.renderer.tldraw.utils import Bounds, DrawPoints, Style
+from bbb_presentation_video.renderer.tldraw.utils import AlwaysMerger, Bounds, DrawPoints, Style
 
 BaseShapeSelf = TypeVar("BaseShapeSelf", bound="BaseShape")
 
@@ -35,10 +35,10 @@ class BaseShape:
         return shape
 
     def update_from_data(self, data: ShapeData) -> None:
-        self.data = data
-
+        self.data = AlwaysMerger.merge(self.data, data)
         if "style" in data:
-            self.style = Style.from_data(data["style"])
+            # use merged style (it can come incomplete)
+            self.style = Style.from_data(self.data["style"])
         if "childIndex" in data:
             self.childIndex = data["childIndex"]
         if "point" in data:

--- a/bbb_presentation_video/renderer/tldraw/utils.py
+++ b/bbb_presentation_video/renderer/tldraw/utils.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Sequence, Tuple, TypeVar, Union
 import attr
 import cairo
 import perfect_freehand
+from deepmerge import Merger
 
 from bbb_presentation_video.events.helpers import Color, color_blend
 from bbb_presentation_video.events.tldraw import StyleData
@@ -281,3 +282,15 @@ def draw_smooth_stroke_point_path(
 ) -> None:
     outline_points = list(map(lambda p: p["point"], points))
     draw_smooth_path(ctx, outline_points, closed)
+
+
+MY_DEFAULT_TYPE_SPECIFIC_MERGE_STRATEGIES = [
+    (list, "override"),
+    (dict, "merge"),
+    (set, "override"),
+]
+
+
+AlwaysMerger = Merger(
+    MY_DEFAULT_TYPE_SPECIFIC_MERGE_STRATEGIES, ["override"], ["override"]
+)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Install requires (keep in sync with setup.cfg)
 # Specific versions are used here to match Ubuntu 20.04
 attrs == 19.3.0
+deepmerge
 lxml
 packaging
 pycairo == 1.16.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 packages = find:
 install_requires =
     attrs >= 19.3.0
+    deepmerge
     lxml
     packaging
     pycairo


### PR DESCRIPTION
Data from udpates can come incomplete (the problem was mainly with style incomplete updates). 
Use deepmerge to merge the old object with the new data.