### PR TITLE
Install the included fonts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
     Private :: Do Not Upload
 
 [options]
-packages = find:
+packages = find_namespace:
 install_requires =
     attrs >= 19.3.0
     lxml
@@ -37,4 +37,5 @@ console_scripts =
     bbb-presentation-video = bbb_presentation_video:main
 
 [options.package_data]
-* = *.pdf
+bbb_presentation_video.renderer = bbb_logo.pdf
+bbb_presentation_video.renderer.tldraw.fonts = *.ttf


### PR DESCRIPTION
Rendering using the included fonts was working from a source checkout, but they weren't getting installed as package data by the python build system, and weren't being included in the debian package. Fix that.