### PR TITLE
New tldraw whiteboard slide scaling calculation

### DIFF
--- a/bbb_presentation_video/renderer/cursor.py
+++ b/bbb_presentation_video/renderer/cursor.py
@@ -249,11 +249,10 @@ class CursorRenderer(Generic[CairoSomeSurface]):
                 continue
 
             ctx.save()
+            apply_shapes_transform(ctx, transform)
             if self.tldraw_whiteboard:
-                apply_slide_transform(ctx, transform)
                 pos = cursor.position
             else:
-                apply_shapes_transform(ctx, transform)
                 pos = Position(
                     cursor.position.x * transform.shapes_size.width,
                     cursor.position.y * transform.shapes_size.height,

--- a/bbb_presentation_video/renderer/tldraw/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/__init__.py
@@ -13,7 +13,7 @@ from bbb_presentation_video.bindings import fontconfig
 from bbb_presentation_video.events import Event, tldraw
 from bbb_presentation_video.renderer.presentation import (
     Transform,
-    apply_slide_transform,
+    apply_shapes_transform,
 )
 from bbb_presentation_video.renderer.tldraw.shape import (
     ArrowShape,
@@ -190,7 +190,7 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
         ctx = self.ctx
         ctx.push_group()
 
-        apply_slide_transform(ctx, transform)
+        apply_shapes_transform(ctx, transform)
 
         for id, s in shapes.items():
             shape = cast(Shape, s)


### PR DESCRIPTION
Starting with BigBlueButton 2.6.0-rc.4, the slides are scaled to fit in a fixed dimension whiteboard, rather than having the whiteboard size be the same as the slide size. This fixes issues where the line widths and sizes of objects like sticky notes would appear to vary dramatically on different slides.

Adapt the shape scaling code to handle this change. A lot of the code is shared with the previous BBB whiteboard code, since a similar scaling method was used there.

Fixes #17