### PR TITLE
Prepare for 4.0.0-rc.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ With the venv activated, you can use `pip` to install the required python
 modules and development tools:
 
 ```sh
-pip install -r requirements-dev.txt
+pip install --upgrade -r requirements-dev.txt
 ```
+
+(You should re-run this occasionally to pull in updates to the development tools.)
 
 Testing
 -------

--- a/bbb_presentation_video/bindings/fontconfig.py
+++ b/bbb_presentation_video/bindings/fontconfig.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import ctypes
 from ctypes import c_char_p, c_int, c_void_p
+from os import PathLike, fsencode
 from typing import Any, Optional, Tuple, Type, Union, cast
 
 
@@ -29,8 +30,6 @@ fontconfig.FcConfigAppFontAddDir.restype = c_int
 fontconfig.FcConfigAppFontAddDir.errcheck = _FcBool_errcheck
 
 
-def app_font_add_dir(dir: Union[str, bytes]) -> None:
+def app_font_add_dir(dir: Union[str, bytes, PathLike[Any]]) -> None:
     """Add fonts from directory to font database in the current configuration."""
-    if isinstance(dir, str):
-        dir = dir.encode()
-    fontconfig.FcConfigAppFontAddDir(None, dir)
+    fontconfig.FcConfigAppFontAddDir(None, fsencode(dir))

--- a/bbb_presentation_video/renderer/tldraw/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/__init__.py
@@ -7,16 +7,15 @@ from __future__ import annotations
 from typing import Dict, Generic, Optional, TypeVar, cast
 
 import cairo
-from pkg_resources import resource_filename
 from sortedcollections import ValueSortedDict
 
 from bbb_presentation_video import events
-from bbb_presentation_video.bindings import fontconfig
 from bbb_presentation_video.events import Event, tldraw
 from bbb_presentation_video.renderer.presentation import (
     Transform,
     apply_shapes_transform,
 )
+from bbb_presentation_video.renderer.tldraw.fonts import add_fontconfig_app_font_dir
 from bbb_presentation_video.renderer.tldraw.shape import (
     ArrowShape,
     DrawShape,
@@ -78,7 +77,7 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
         self.shape_patterns = {}
         self.transform = transform
 
-        fontconfig.app_font_add_dir(resource_filename(__name__, "fonts"))
+        add_fontconfig_app_font_dir()
 
     def ensure_shape_structure(self, presentation: str, slide: int) -> None:
         """Create the nested dict entries for storing shapes per presentation and slide."""

--- a/bbb_presentation_video/renderer/tldraw/fonts/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/fonts/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2022 BigBlueButton Inc. and by respective authors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import atexit
+from contextlib import ExitStack
+from importlib import resources
+from os import path
+
+from bbb_presentation_video.bindings import fontconfig
+
+__fontconfig_app_font_dir_added = False
+
+
+def add_fontconfig_app_font_dir() -> None:
+    global __fontconfig_app_font_dir_added
+    if __fontconfig_app_font_dir_added:
+        return
+
+    stack = ExitStack()
+
+    font_dirs = set()
+    for filename in resources.contents(__package__):
+        if not filename.endswith(".ttf"):
+            continue
+        abspath = stack.enter_context(resources.path(__package__, filename))
+        font_dirs.add(path.dirname(abspath))
+
+    try:
+        for dir in font_dirs:
+            print(dir)
+            fontconfig.app_font_add_dir(dir)
+    except fontconfig.FontconfigError:
+        stack.close()
+        return
+
+    atexit.register(stack.close)
+    __fontconfig_app_font_dir_added = True

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bbb-presentation-video (4.0.0~rc1) focal; urgency=medium
+
+  * Arrow labels, Performance improvements, and cleanups
+
+ -- Calvin Walton <calvin.walton@blindsidenetworks.com>  Fri, 03 Mar 2023 13:44:57 -0500
+
 bbb-presentation-video (4.0.0~beta5) focal; urgency=medium
 
   * New tldraw whiteboard slide scaling calculation

--- a/debian/control
+++ b/debian/control
@@ -5,19 +5,15 @@ Maintainer: Calvin Walton <calvin.walton@kepstin.ca>
 Build-Depends: debhelper (>= 10.0.0),
  dh-python,
  python3 (>= 3.8),
- python3-setuptools
+ python3-setuptools,
+ python3-setuptools-scm
 Standards-Version: 3.9.2
 X-Python3-Version: >= 3.8
 
 Package: bbb-presentation-video
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends},
- python3-attr,
- python3-cairo,
- python3-gi,
  python3-gi-cairo,
- python3-lxml,
- python3-pkg-resources,
  python3-perfect-freehand (>= 1.2.0),
  gir1.2-glib-2.0,
  gir1.2-poppler-0.18,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 [build-system]
-requires = ["setuptools >= 42"]
+requires = ["setuptools >= 42", "setuptools_scm[toml] >= 3.4"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
+[tool.black]
+target-version = ["py38"]
+
 [tool.isort]
+py_version = "38"
 profile = "black"
 
 [tool.mypy]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,14 @@
 # Install requires (keep in sync with setup.cfg)
 # Specific versions are used here to match Ubuntu 20.04
+setuptools == 45.2.0
+setuptools_scm == 3.4.3
 attrs == 19.3.0
-lxml
-packaging
+lxml == 4.5.0
+packaging == 20.3
 pycairo == 1.16.2
-pygobject
-sortedcollections
-perfect-freehand
+pygobject == 3.36.0
+sortedcollections == 1.0.1
+perfect-freehand >= 1.2.0
 
 # Code formatting
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,13 +4,11 @@
 
 [metadata]
 name = bbb-presentation-video
-version = 4.0.0-beta.5
 description = Render BigBlueButton recording events.xml file to a video
 author = BigBlueButton Inc.
 url = https://github.com/bigbluebutton/bbb-presentation-video
 license = GPL-3.0-or-later
 license_files = LICENSES/*
-python_requires = >= 3.8
 classifiers =
     Environment :: Console
     Intended Audience :: Developers
@@ -23,14 +21,23 @@ classifiers =
 
 [options]
 packages = find_namespace:
+python_requires = >= 3.8
+setup_requires =
+    setuptools_scm
 install_requires =
     attrs >= 19.3.0
-    lxml
-    packaging
-    pycairo
-    pygobject
-    sortedcollections
-    perfect-freehand
+    lxml >= 4.5.0
+    packaging >= 20.3
+    pycairo >= 1.16.2
+    pygobject >= 3.36.0
+    sortedcollections >= 1.0.1
+    perfect-freehand >= 1.2.0
+
+
+[options.packages.find]
+include =
+    bbb_presentation_video
+    bbb_presentation_video.*
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,6 @@
 
 from setuptools import setup
 
-setup()
+setup(
+    use_scm_version=True,
+)

--- a/typings/gi/repository/GObject.pyi
+++ b/typings/gi/repository/GObject.pyi
@@ -1,0 +1,14 @@
+class Object:
+    """The base object type.
+
+    All the fields in the `GObject` structure are private to the implementation
+    and should never be accessed directly.
+
+    Since GLib 2.72, all #GObjects are guaranteed to be aligned to at least the
+    alignment of the largest basic GLib type (typically this is #guint64 or
+    #gdouble). If you need larger alignment for an element in a #GObject, you
+    should allocate it on the heap (aligned), or arrange for your #GObject to be
+    appropriately padded. This guarantee applies to the #GObject (or derived)
+    struct, the #GObjectClass (or derived) struct, and any private data allocated
+    by G_ADD_PRIVATE().
+    """

--- a/typings/gi/repository/Gio.pyi
+++ b/typings/gi/repository/Gio.pyi
@@ -1,0 +1,30 @@
+"""Gio is a library providing useful classes for general purpose I/O, networking, IPC,
+settings, and other high level application functionality
+"""
+
+from gi.repository import GObject
+
+# Classes
+
+class Cancellable(GObject.Object):
+    """GCancellable is a thread-safe operation cancellation stack used
+    throughout GIO to allow for cancellation of synchronous and
+    asynchronous operations."""
+
+# Interfaces
+
+class File(GObject.Object):
+    """GFile is a high level abstraction for manipulating files on a virtual file
+    system.
+
+    GFiles are lightweight, immutable objects that do no I/O upon creation. It is
+    necessary to understand that GFile objects do not represent files, merely an
+    identifier for a file. All file content I/O is implemented as streaming operations
+    (see GInputStream and GOutputStream).
+    """
+
+    @classmethod
+    def new_for_path(cls, path: str | bytes) -> File:
+        """Constructs a GFile for a given path. This operation never fails, but the
+        returned object might not support any I/O operation if path is malformed.
+        """

--- a/typings/gi/repository/Poppler.pyi
+++ b/typings/gi/repository/Poppler.pyi
@@ -6,8 +6,19 @@
 from typing import Optional, Tuple
 
 import cairo
+from gi.repository import Gio
 
 class Document:
+    @classmethod
+    def new_from_gfile(
+        cls,
+        file: Gio.File,
+        password: Optional[str],
+        cancellable: Optional[Gio.Cancellable],
+    ) -> Document:
+        """Creates a new #PopplerDocument reading the PDF contents from @file.
+        Possible errors include those in the #POPPLER_ERROR and #G_FILE_ERROR
+        domains."""
     @classmethod
     def new_from_file(cls, uri: str, password: Optional[str] = None) -> Document: ...
     def get_n_pages(self) -> int: ...


### PR DESCRIPTION
* Remove use of (undeclared dependency on) pkg_resources, replacing it with stdlib importlib.resources (tho this does make loading fonts more complicated).
* Remove some manual dependencies on python packages that are inferred by debian pybuild.
* Use setuptools_scm for setting version number to reduce the number of places where the version number has to be updated.
* Clean up some filesystem path code to ensure paths are correctly encoded.