### PR TITLE
Handle arrow updates which remove decorations

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import Dict, Optional, Protocol, Tuple, Type, TypeVar, Union
 
 import attr
 import cairo
 
 from bbb_presentation_video.events.helpers import Position, Size
-from bbb_presentation_video.events.tldraw import ShapeData
+from bbb_presentation_video.events.tldraw import HandleData, ShapeData
 from bbb_presentation_video.renderer.tldraw.utils import Decoration, DrawPoints, Style
 
 BaseShapeSelf = TypeVar("BaseShapeSelf", bound="BaseShapeProto")
@@ -193,11 +193,23 @@ class ArrowHandles:
         self.bend = bend
         self.end = end
 
+    def update_from_data(self, data: Dict[str, HandleData]) -> None:
+        if "start" in data:
+            self.start = Position(data["start"]["point"])
+        if "bend" in data:
+            self.bend = Position(data["bend"]["point"])
+        if "end" in data:
+            self.end = Position(data["end"]["point"])
+
 
 @attr.s(order=False, slots=True, auto_attribs=True)
 class ArrowDecorations:
     start: Optional[Decoration] = None
     end: Optional[Decoration] = Decoration.ARROW
+
+    def update_from_data(self, data: Dict[str, Optional[str]]) -> None:
+        self.start = Decoration(data["start"]) if "start" in data else None
+        self.end = Decoration(data["end"]) if "end" in data else None
 
 
 @attr.s(order=False, slots=True, auto_attribs=True)
@@ -215,26 +227,10 @@ class ArrowShape(LabelledShapeProto):
 
         if "bend" in data:
             self.bend = data["bend"]
-
         if "handles" in data:
-            handles = data["handles"]
-            if "start" in handles:
-                self.handles.start = Position(handles["start"]["point"])
-            if "end" in handles:
-                self.handles.end = Position(handles["end"]["point"])
-            if "bend" in handles:
-                self.handles.bend = Position(handles["bend"]["point"])
-
+            self.handles.update_from_data(data["handles"])
         if "decorations" in data:
-            decorations = data["decorations"]
-            if "start" in decorations:
-                start = decorations["start"]
-                self.decorations.start = (
-                    Decoration(start) if start is not None else None
-                )
-            if "end" in decorations:
-                end = decorations["end"]
-                self.decorations.end = Decoration(end) if end is not None else None
+            self.decorations.update_from_data(data["decorations"])
 
 
 Shape = Union[

--- a/tests/renderer/tldraw/test_shape.py
+++ b/tests/renderer/tldraw/test_shape.py
@@ -155,3 +155,38 @@ def test_arrow_from_data() -> None:
     assert arrow.handles.bend == Position(52.21, 58.1)
     assert arrow.decorations.end == Decoration.ARROW
     assert arrow.decorations.start is None
+
+
+def test_arrow_from_data_no_decorations() -> None:
+    data: ShapeData = {
+        "size": [13.42, 699.31],
+        "label": "",
+        "rotation": 0,
+        "bend": -2.743172580401816e-7,
+        "id": "06fd6107-381a-4133-32ac-9ffc2f67e030",
+        "labelPoint": [0.5, 0.5],
+        "decorations": {},
+        "parentId": "1",
+        "childIndex": 0,
+        "name": "Arrow",
+        "point": [199.43, 311.63],
+        "style": {
+            "isFilled": False,
+            "size": "small",
+            "scale": 1,
+            "color": "black",
+            "textAlign": "start",
+            "font": "script",
+            "dash": "draw",
+        },
+        "handles": {
+            "start": {"id": "start", "index": 0, "point": [0, 699.31], "canBind": True},
+            "end": {"id": "end", "index": 1, "point": [13.42, 0], "canBind": True},
+            "bend": {"id": "bend", "index": 2, "point": [6.71, 349.66]},
+        },
+        "userId": "w_ojf9vuncwica",
+        "type": "arrow",
+    }
+    arrow = ArrowShape.from_data(data)
+    assert arrow.decorations.start is None
+    assert arrow.decorations.end is None


### PR DESCRIPTION
When drawing a line (arrow with no decorations), tldraw omits the keys for the 'start' and 'end' decorations from the decorations object in the data json completely, rather than leaving the keys and setting the value to null.

Handle this by removing the decoration if it was omitted in the json.

Fixes #27