### PR TITLE
Ensure scale_adj is always initialized

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/text.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/text.py
@@ -180,6 +180,7 @@ def finalize_label(
 
     label_size = get_layout_size(layout, padding=4)
     # The shape may provide a scale adjustment to reduce label size if it wouldn't fit
+    scale_adj = 1.0
     if scale is not None:
         scale_adj = scale(label_size)
         label_size *= scale_adj


### PR DESCRIPTION
`scale_adj` is being returned from the `finalize_label` function, but it only gets initialized if the shape provides a `scale` callback. This results in an error on any shape other than an arrow with a label.

Initialize the variable to 1.0 (no adjustment) to avoid the error.

Fixes #25