### PR TITLE
Fix curved arrow dist return value

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/arrow.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/arrow.py
@@ -312,7 +312,7 @@ def curved_arrow(
     ctx.set_source_rgb(stroke.r, stroke.g, stroke.b)
     ctx.stroke()
 
-    return length
+    return abs(length)
 
 
 def finalize_arrow(


### PR DESCRIPTION
Dist was being returned negative depending on the arc, which affected the label size scale calculation.

![label_size](https://user-images.githubusercontent.com/2726293/224803578-9c3fdf91-3c55-4dc8-863f-9a932e07c380.png)

Reference: https://github.com/tldraw/tldraw/blob/4ea39a0263cc12ca1ac6acc13c4cd1f57d8a16b2/packages/tldraw/src/state/shapes/ArrowUtil/ArrowUtil.tsx#L130
