### PR TITLE
Fix render loop access to recording length var

### DIFF
--- a/bbb_presentation_video/renderer/__init__.py
+++ b/bbb_presentation_video/renderer/__init__.py
@@ -4,12 +4,11 @@
 
 import threading
 import time
-from collections import deque
 from enum import Enum
 from fractions import Fraction
 from queue import Queue
 from subprocess import PIPE, CalledProcessError, Popen
-from typing import Deque, Iterable, Optional, cast
+from typing import Optional, cast
 
 import cairo
 
@@ -224,7 +223,8 @@ class Renderer:
         shapes_changed = False
         cursor_changed = False
         recording_changed = False
-        while self.pts < self.length:
+        assert self.events.length is not None
+        while self.pts < self.events.length:
             event_ts = Fraction(0)
             while True:
                 if len(self.events.events) == 0:


### PR DESCRIPTION
This was missed during the work preparing for 4.0.0, and broke things.