### PR TITLE
Handle arrow updates with empty handle hash.

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -194,12 +194,18 @@ class ArrowHandles:
         self.end = end
 
     def update_from_data(self, data: Dict[str, HandleData]) -> None:
-        if "start" in data:
+        try:
             self.start = Position(data["start"]["point"])
-        if "bend" in data:
+        except KeyError:
+            pass
+        try:
             self.bend = Position(data["bend"]["point"])
-        if "end" in data:
+        except KeyError:
+            pass
+        try:
             self.end = Position(data["end"]["point"])
+        except KeyError:
+            pass
 
 
 @attr.s(order=False, slots=True, auto_attribs=True)


### PR DESCRIPTION
For some reason when updating the position of a shape, tldraw sometimes sends and update with the "start" handle present, but its value is an empty hash (no "point").

Wrap the code in an exception handler for KeyError so I don't have to individually check each level of the hash.

Fixes #36