### PR TITLE
Ignore tldraw add shape with missing type field.

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/__init__.py
@@ -145,9 +145,13 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
             shape.update_from_data(data)
             action = "updated"
         else:
-            shape = parse_shape_from_data(data)
-            self.shapes[presentation][slide][id] = shape
-            action = "added"
+            if "type" in data:
+                shape = parse_shape_from_data(data)
+                self.shapes[presentation][slide][id] = shape
+                action = "added"
+            else:
+                print(f'\tTldraw: Got add for shape: {id} with missing "type" field')
+                return
 
         try:
             del self.shape_patterns[id]


### PR DESCRIPTION
We sometimes see events produced by BigBlueButton which look like "update" events - they only have an id and point field (what you'd see if you drag a shape to a different position), but they refer to a shape id that hasn't previously been seen in the events file.

There's nothing that can be done except ignore the shape (and log a message).

My suspicion is that the presenter might have triggered a bug which let them drag the slide background image, since the events for the background image are filtered out of the events.