### PR TITLE
Update python baseline to 3.10 (ubuntu 22.04)

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/utils.py
+++ b/bbb_presentation_video/renderer/tldraw/utils.py
@@ -28,13 +28,13 @@ STICKY_PADDING: float = 16.0
 
 
 class SizeStyle(Enum):
-    SMALL: str = "small"
-    S: str = "s"
-    MEDIUM: str = "medium"
-    M: str = "m"
-    LARGE: str = "large"
-    L: str = "l"
-    XL: str = "xl"
+    SMALL = "small"
+    S = "s"
+    MEDIUM = "medium"
+    M = "m"
+    LARGE = "large"
+    L = "l"
+    XL = "xl"
 
 
 STROKE_WIDTHS: Dict[SizeStyle, float] = {
@@ -71,24 +71,24 @@ LETTER_SPACING: float = -0.03  # em
 
 
 class ColorStyle(Enum):
-    WHITE: str = "white"
-    LIGHT_GRAY: str = "lightGray"
-    GRAY: str = "gray"
-    GREY: str = "grey"
-    BLACK: str = "black"
-    GREEN: str = "green"
-    LIGHT_GREEN: str = "light-green"
-    CYAN: str = "cyan"
-    BLUE: str = "blue"
-    LIGHT_BLUE: str = "light-blue"
-    INDIGO: str = "indigo"
-    VIOLET: str = "violet"
-    LIGHT_VIOLET: str = "light-violet"
-    RED: str = "red"
-    LIGHT_RED: str = "light-red"
-    ORANGE: str = "orange"
-    YELLOW: str = "yellow"
-    SEMI: str = "semi"
+    WHITE = "white"
+    LIGHT_GRAY = "lightGray"
+    GRAY = "gray"
+    GREY = "grey"
+    BLACK = "black"
+    GREEN = "green"
+    LIGHT_GREEN = "light-green"
+    CYAN = "cyan"
+    BLUE = "blue"
+    LIGHT_BLUE = "light-blue"
+    INDIGO = "indigo"
+    VIOLET = "violet"
+    LIGHT_VIOLET = "light-violet"
+    RED = "red"
+    LIGHT_RED = "light-red"
+    ORANGE = "orange"
+    YELLOW = "yellow"
+    SEMI = "semi"
 
 
 COLORS: Dict[ColorStyle, Color] = {
@@ -255,20 +255,20 @@ V2_COLORS: Dict[ColorStyle, V2Color] = {
 
 
 class DashStyle(Enum):
-    DRAW: str = "draw"
-    SOLID: str = "solid"
-    DASHED: str = "dashed"
-    DOTTED: str = "dotted"
+    DRAW = "draw"
+    SOLID = "solid"
+    DASHED = "dashed"
+    DOTTED = "dotted"
 
 
 class FontStyle(Enum):
-    SCRIPT: str = "script"
-    SANS: str = "sans"
-    ERIF: str = "erif"  # Old tldraw versions had this spelling mistake
-    SERIF: str = "serif"
-    MONO: str = "mono"
-    DRAW: str = "draw"
-    ARIAL: str = "arial"
+    SCRIPT = "script"
+    SANS = "sans"
+    ERIF = "erif"  # Old tldraw versions had this spelling mistake
+    SERIF = "serif"
+    MONO = "mono"
+    DRAW = "draw"
+    ARIAL = "arial"
 
 
 FONT_FACES: Dict[FontStyle, str] = {
@@ -283,17 +283,17 @@ FONT_FACES: Dict[FontStyle, str] = {
 
 
 class AlignStyle(Enum):
-    START: str = "start"
-    MIDDLE: str = "middle"
-    END: str = "end"
-    JUSTIFY: str = "justify"
+    START = "start"
+    MIDDLE = "middle"
+    END = "end"
+    JUSTIFY = "justify"
 
 
 class FillStyle(Enum):
-    NONE: str = "none"
-    SEMI: str = "semi"
-    SOLID: str = "solid"
-    PATTERN: str = "pattern"
+    NONE = "none"
+    SEMI = "semi"
+    SOLID = "solid"
+    PATTERN = "pattern"
 
 
 @attr.s(order=False, slots=True, auto_attribs=True)
@@ -337,40 +337,40 @@ class Style:
 
 
 class Decoration(Enum):
-    ARROW: str = "arrow"
-    BAR: str = "bar"
-    DIAMOND: str = "diamond"
-    DOT: str = "dot"
-    INVERTED: str = "inverted"
-    NONE: str = "none"
-    SQUARE: str = "square"
-    TRIANGLE: str = "triangle"
+    ARROW = "arrow"
+    BAR = "bar"
+    DIAMOND = "diamond"
+    DOT = "dot"
+    INVERTED = "inverted"
+    NONE = "none"
+    SQUARE = "square"
+    TRIANGLE = "triangle"
 
 
 class SplineType(Enum):
-    CUBIC: str = "cubic"
-    LINE: str = "line"
-    NONE: str = "none"
+    CUBIC = "cubic"
+    LINE = "line"
+    NONE = "none"
 
 
 class GeoShape(Enum):
-    ARROW_DOWN: str = "arrow-down"
-    ARROW_LEFT: str = "arrow-left"
-    ARROW_RIGHT: str = "arrow-right"
-    ARROW_UP: str = "arrow-up"
-    CHECKBOX: str = "check-box"
-    CLOUD: str = "cloud"
-    DIAMOND: str = "diamond"
-    ELLIPSE: str = "ellipse"
-    HEXAGON: str = "hexagon"
-    NONE: str = ""
-    OVAL: str = "oval"
-    RECTANGLE: str = "rectangle"
-    RHOMBUS: str = "rhombus"
-    STAR: str = "star"
-    TRAPEZOID: str = "trapezoid"
-    TRIANGLE: str = "triangle"
-    XBOX: str = "x-box"
+    ARROW_DOWN = "arrow-down"
+    ARROW_LEFT = "arrow-left"
+    ARROW_RIGHT = "arrow-right"
+    ARROW_UP = "arrow-up"
+    CHECKBOX = "check-box"
+    CLOUD = "cloud"
+    DIAMOND = "diamond"
+    ELLIPSE = "ellipse"
+    HEXAGON = "hexagon"
+    NONE = ""
+    OVAL = "oval"
+    RECTANGLE = "rectangle"
+    RHOMBUS = "rhombus"
+    STAR = "star"
+    TRAPEZOID = "trapezoid"
+    TRIANGLE = "triangle"
+    XBOX = "x-box"
 
 
 def perimeter_of_ellipse(rx: float, ry: float) -> float:

--- a/constraints-ubuntu-focal.txt
+++ b/constraints-ubuntu-focal.txt
@@ -1,9 +1,0 @@
-attrs == 19.3.0
-lxml == 4.5.0
-packaging == 20.3
-pycairo == 1.16.2
-pygobject == 3.36.0
-pyparsing == 2.4.6
-sortedcollections == 1.0.1
-sortedcontainers == 2.1.0
-six == 1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ build-backend = "setuptools.build_meta"
 version_scheme = "post-release"
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 [tool.isort]
-py_version = "38"
+py_version = "310"
 profile = "black"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 strict = true
 files = "."
 mypy_path = "$MYPY_CONFIG_FILE_DIR/typings"

--- a/typings/gi/repository/Pango.pyi
+++ b/typings/gi/repository/Pango.pyi
@@ -5,7 +5,7 @@
 """Internationalized text layout and rendering"""
 
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Optional, Tuple, cast
 
 from gi.repository import GObject
 
@@ -353,36 +353,36 @@ class Alignment(Enum):
     the interpretation of :class:`Pango.Alignment` values.
     """
 
-    LEFT: int
+    LEFT = cast(int, ...)
     """Put all available space on the right"""
-    CENTER: int
+    CENTER = cast(int, ...)
     """Center the line within the available space"""
-    RIGHT: int
+    RIGHT = cast(int, ...)
     """Put all available space on the left"""
 
 class Direction(Enum):
     """PangoDirection represents a direction in the Unicode bidirectional algorithm."""
 
-    LTR: int
+    LTR = cast(int, ...)
     """A strong left-to-right direction."""
-    RTL: int
+    RTL = cast(int, ...)
     """A strong right-to-left direction."""
-    TTB_LTR: int
+    TTB_LTR = cast(int, ...)
     """Deprecated value; treated the same as `RTL`."""
-    TTB_RTL: int
+    TTB_RTL = cast(int, ...)
     """Deprecated value; treated the same as `LTR`."""
-    WEAK_LTR: int
+    WEAK_LTR = cast(int, ...)
     """A weak left-to-right direction."""
-    WEAK_RTL: int
+    WEAK_RTL = cast(int, ...)
     """A weak right-to-left direction."""
-    NEUTRAL: int
+    NEUTRAL = cast(int, ...)
     """No direction specified."""
 
 class EllipsizeMode(Enum):
-    NONE: int
-    START: int
-    MIDDLE: int
-    END: int
+    NONE = cast(int, ...)
+    START = cast(int, ...)
+    MIDDLE = cast(int, ...)
+    END = cast(int, ...)
 
 class Weight(Enum):
     """An enumeration specifying the weight (boldness) of a font.
@@ -390,29 +390,29 @@ class Weight(Enum):
     Weight is specified as a numeric value ranging from 100 to 1000.
     This enumeration simply provides some common, predefined values."""
 
-    THIN: int
+    THIN = 100
     """the thin weight (= 100) Since: 1.24"""
-    ULTRALIGHT: int
+    ULTRALIGHT = 200
     """the ultralight weight (= 200)"""
-    LIGHT: int
+    LIGHT = 300
     """the light weight (= 300)"""
-    SEMILIGHT: int
+    SEMILIGHT = 350
     """the semilight weight (= 350) Since: 1.36.7"""
-    BOOK: int
+    BOOK = 380
     """the book weight (= 380) Since: 1.24)"""
-    NORMAL: int
+    NORMAL = 400
     """the default weight (= 400)"""
-    MEDIUM: int
+    MEDIUM = 500
     """the medium weight (= 500) Since: 1.24"""
-    SEMIBOLD: int
+    SEMIBOLD = 600
     """the semibold weight (= 600)"""
-    BOLD: int
+    BOLD = 700
     """the bold weight (= 700)"""
-    ULTRABOLD: int
+    ULTRABOLD = 800
     """the ultrabold weight (= 800)"""
-    HEAVY: int
+    HEAVY = 900
     """the heavy weight (= 900)"""
-    ULTRAHEAVY: int
+    ULTRAHEAVY = 1000
     """the ultraheavy weight (= 1000) Since: 1.24"""
 
 class WrapMode(Enum):
@@ -425,11 +425,11 @@ class WrapMode(Enum):
     segmentation algorithm.
     """
 
-    WORD: int
+    WORD = cast(int, ...)
     """wrap lines at word boundaries."""
-    CHAR: int
+    CHAR = cast(int, ...)
     """wrap lines at character boundaries."""
-    WORD_CHAR: int
+    WORD_CHAR = cast(int, ...)
     """wrap lines at word boundaries, but fall back to
     character boundaries if there is not enough space for a full word.
     """


### PR DESCRIPTION
Set the mypy, isort, and black tools to use the python 3.10 mode. Fix some issues reported by mypy regarding changes in parsing enum values. Drop the library version presets file for ubuntu xenial.