### PR TITLE
Always enable wrapping in tldraw 2 text tool

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/v2/shape/text.py
+++ b/bbb_presentation_video/renderer/tldraw/v2/shape/text.py
@@ -60,11 +60,8 @@ def finalize_text(
     ctx.push_group()
 
     width = None
-    wrap = False
-    if not shape.auto_size:
-        wrap = True
-        if shape.size.width > 0:
-            width = shape.size.width
+    if not shape.auto_size and shape.size.width > 0:
+        width = shape.size.width
 
     layout = create_pango_layout(
         ctx,
@@ -73,7 +70,6 @@ def finalize_text(
         FONT_SIZES[style.size],
         width=width,
         align=shape.align,
-        wrap=wrap,
         letter_spacing=None,
     )
     layout.set_text(shape.text, -1)


### PR DESCRIPTION
Disabling wrapping puts the text rendering into single-line ellipsised mode (intended for frame labels), which stops someone from being able to manually break lines by pressing enter. (Only the first line will be shown)

Always allow wrapping (which is the default) for the text tool.