### PR TITLE
Fix zero-width tldraw v2 sticky notes in video recordings

### DIFF
--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -21,6 +21,13 @@ from bbb_presentation_video.renderer.tldraw.utils import (
     Style,
 )
 
+NOTE_SIZE = 200.0
+"""Side length of a tldraw v2 note (sticky) shape.
+
+Note shapes are a fixed square of this size on the client (tldraw's NOTE_SIZE
+constant). Unlike geo shapes they carry no w/h props; they only grow vertically
+via the growY prop."""
+
 BaseShapeSelf = TypeVar("BaseShapeSelf", bound="BaseShapeProto")
 
 
@@ -422,7 +429,7 @@ class StickyShapeV2(RotatableShapeProto):
     text: str = ""
     align: AlignStyle = AlignStyle.MIDDLE
     verticalAlign: AlignStyle = AlignStyle.MIDDLE
-    size: Size = Size(200.0, 200.0)
+    size: Size = Size(NOTE_SIZE, NOTE_SIZE)
 
     def update_from_data(self, data: ShapeData) -> None:
         super().update_from_data(data)
@@ -435,10 +442,15 @@ class StickyShapeV2(RotatableShapeProto):
                 self.align = AlignStyle(props["align"])
             if "verticalAlign" in props:
                 self.verticalAlign = AlignStyle(props["verticalAlign"])
-            if "growY" in props:
-                self.size = Size(self.size.width, self.size.height + props["growY"])
-                if props["growY"] != 0:
-                    self.verticalAlign = AlignStyle.START
+
+            # Note shapes carry no w/h props, so SizedShapeProto collapsed the
+            # size to Size(0, growY). Override it with the fixed NOTE_SIZE square
+            # that grows vertically by growY, applied exactly once (not on top of
+            # the value the parent already added).
+            grow_y = props["growY"] if "growY" in props else 0.0
+            self.size = Size(NOTE_SIZE, NOTE_SIZE + grow_y)
+            if grow_y != 0:
+                self.verticalAlign = AlignStyle.START
 
 
 @attr.s(order=False, slots=True, auto_attribs=True, init=False)

--- a/tests/renderer/tldraw/test_shape.py
+++ b/tests/renderer/tldraw/test_shape.py
@@ -5,9 +5,11 @@ from bbb_presentation_video.renderer.tldraw.shape import (
     DrawShape,
     HighlighterShape,
     LineShape,
+    StickyShapeV2,
 )
 from bbb_presentation_video.renderer.tldraw.utils import (
     HIGHLIGHT_COLORS,
+    AlignStyle,
     ColorStyle,
     DashStyle,
     Decoration,
@@ -265,6 +267,58 @@ def test_line_from_data() -> None:
     assert line.handles.start == Position(0, 0)
     assert line.handles.controlPoint == Position(-71, 216)
     assert line.handles.end == Position(-229, 377)
+
+
+def _note_data(grow_y: float) -> ShapeData:
+    # A tldraw v2 "note" (sticky) shape. Note shapes carry NO w/h props: the box
+    # is a fixed NOTE_SIZE (200) square on the client that grows vertically by
+    # growY. The `size` prop is the font size ("m"), not a geometry size.
+    return {
+        "x": 100,
+        "y": 200,
+        "rotation": 0,
+        "typeName": "shape",
+        "opacity": 1,
+        "parentId": "page:1",
+        "index": "a1",
+        "id": "shape:noteExample",
+        "type": "note",
+        "props": {
+            "color": "yellow",
+            "size": "m",
+            "text": "Hello",
+            "font": "draw",
+            "align": "middle",
+            "verticalAlign": "middle",
+            "growY": grow_y,
+            "url": "",
+        },
+    }
+
+
+def test_sticky_v2_defaults() -> None:
+    sticky = StickyShapeV2()
+    assert sticky.size == Size(200, 200)
+    assert sticky.text == ""
+    assert sticky.align == AlignStyle.MIDDLE
+    assert sticky.verticalAlign == AlignStyle.MIDDLE
+
+
+def test_sticky_v2_from_data_no_grow() -> None:
+    # Regression: a note with no vertical growth must keep the full 200x200 box.
+    # The bug collapsed width to 0 (naked text spilling right in the VIDEO format).
+    sticky = StickyShapeV2.from_data(_note_data(grow_y=0))
+    assert sticky.text == "Hello"
+    assert sticky.align == AlignStyle.MIDDLE
+    assert sticky.size == Size(200, 200)
+
+
+def test_sticky_v2_from_data_grown() -> None:
+    # Regression: growY must be applied exactly once, on top of the base height.
+    # The bug both collapsed width to 0 and double-counted growY (200,320 -> 0,240).
+    sticky = StickyShapeV2.from_data(_note_data(grow_y=120))
+    assert sticky.size == Size(200, 320)
+    assert sticky.verticalAlign == AlignStyle.START
 
 
 def test_highlight_from_data() -> None:


### PR DESCRIPTION
## What this fixes

In the video recording format, every tldraw v2 sticky note collapsed to a zero-width box: the yellow note was not drawn and its text spilled out to the right instead of wrapping inside the box. The presentation format rendered the same notes correctly, so the bug was specific to this renderer.

## Root cause

tldraw v2 note shapes do not carry w/h props. The box is a fixed 200px square on the client (tldraw's NOTE_SIZE) that only grows vertically via the growY prop. Real note props are align, color, font, growY, size, text, url, verticalAlign (the size prop is the font size, not a geometry size).

Two bugs stacked up in `bbb_presentation_video/renderer/tldraw/shape/__init__.py`:

1. StickyShapeV2 inherits SizedShapeProto.update_from_data, which reads the absent w/h as 0 and sets `self.size = Size(0, growY)`, overwriting the `Size(200, 200)` default.
2. StickyShapeV2.update_from_data then added growY a second time: `Size(self.size.width, self.size.height + growY)`, giving `Size(0, 2*growY)`.

The text wrap width in `finalize_sticky_text` is taken from `shape.size.width`, so width 0 is exactly why the text could not wrap and spilled to the right. Geo shapes go through the same SizedShapeProto path but survive because their props do carry real w/h.

## The fix

For note shapes, set the size directly from a fixed NOTE_SIZE base plus growY applied once, bypassing the w/h path that does not apply to notes:

```python
NOTE_SIZE = 200.0
...
grow_y = props["growY"] if "growY" in props else 0.0
self.size = Size(NOTE_SIZE, NOTE_SIZE + grow_y)
```

NOTE_SIZE = 200.0 is a named module constant (matches the existing `Size(200.0, 200.0)` defaults of both sticky classes and tldraw's client-side NOTE_SIZE). Geo and v1 sticky shapes are untouched.

## Visual proof

Sticky note rendered through the real `finalize_v2_sticky` path (direct renderer render, before/after the fix):

![Sticky note: BEFORE zero-width text spills vs AFTER 200x320 yellow box with wrapped text](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-31/1590c873-c5c7-4656-8bb7-20860ba40a29/sticky_compare.png)

This is a deterministic size-computation bug; the renderer-level render is authoritative proof (the full BBB record-and-playback pipeline feeds the same `shape.size` into cairo). A full E2E recording run would exercise the same code path at far greater cost.

## Tests

Added regression tests in `tests/renderer/tldraw/test_shape.py` asserting StickyShapeV2 size after `update_from_data`:

- growY = 0   -> Size(200, 200)  (was Size(0, 0))
- growY = 120 -> Size(200, 320)  (was Size(0, 240))

`black --check`, `isort --check`, `mypy` (strict) and `pytest` all pass locally.

Closes bigbluebutton/bigbluebutton#25557

