### PR TITLE
Render images pasted onto the whiteboard in the video format

### DIFF
--- a/bbb_presentation_video/renderer/__init__.py
+++ b/bbb_presentation_video/renderer/__init__.py
@@ -244,7 +244,7 @@ class Renderer:
         )
         shapes = ShapesRenderer(self.ctx, presentation.transform)
         tldraw = TldrawRenderer(
-            self.ctx, presentation.transform, self.events.bbb_version
+            self.ctx, self.input, presentation.transform, self.events.bbb_version
         )
 
         encoder = Encoder(

--- a/bbb_presentation_video/renderer/tldraw/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/__init__.py
@@ -31,6 +31,7 @@ from bbb_presentation_video.renderer.tldraw.shape import (
     GroupShape,
     HexagonGeoShape,
     HighlighterShape,
+    ImageShape,
     LineShape,
     OvalGeoShape,
     PollShape,
@@ -82,6 +83,7 @@ from bbb_presentation_video.renderer.tldraw.v2.shape.frame import (
 from bbb_presentation_video.renderer.tldraw.v2.shape.hexagon_geo_shape import (
     finalize_hexagon,
 )
+from bbb_presentation_video.renderer.tldraw.v2.shape.image import finalize_image
 from bbb_presentation_video.renderer.tldraw.v2.shape.oval_geo_shape import finalize_oval
 from bbb_presentation_video.renderer.tldraw.v2.shape.rectangle_geo_shape import (
     finalize_geo_rectangle,
@@ -115,6 +117,9 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
     ctx: cairo.Context[CairoSomeSurface]
     """The cairo rendering context for drawing the whiteboard."""
 
+    directory: str
+    """The directory of the recording, which holds the uploaded image files."""
+
     presentation: Optional[str] = None
     """The current presentation."""
 
@@ -144,10 +149,12 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
     def __init__(
         self,
         ctx: cairo.Context[CairoSomeSurface],
+        directory: str,
         transform: Transform,
         bbb_version: Version,
     ):
         self.ctx = ctx
+        self.directory = directory
         self.presentation_slide = {}
         self.shapes = {}
         self.shape_patterns = {}
@@ -210,10 +217,6 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
         slide = event["slide"]
         id = event["id"]
         data = event["data"]
-
-        if "type" in data and data["type"] == "image":
-            print(f"\tTldraw: ignoring image shape type: {id}")
-            return
 
         self.ensure_shape_structure(presentation, slide)
 
@@ -324,6 +327,8 @@ class TldrawRenderer(Generic[CairoSomeSurface]):
                 finalize_hexagon(ctx, id, shape)
             elif isinstance(shape, HighlighterShape):
                 finalize_highlight(ctx, id, shape)
+            elif isinstance(shape, ImageShape):
+                finalize_image(ctx, id, shape, self.directory)
             elif isinstance(shape, LineShape):
                 finalize_line(ctx, id, shape)
             elif isinstance(shape, OvalGeoShape):

--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -268,7 +268,7 @@ class ImageShape(RotatableShapeProto):
     """Location of the image, as recorded by the whiteboard client."""
 
     pixbuf: Optional[GdkPixbuf.Pixbuf] = None
-    """The decoded image, cached after the first render."""
+    """The decoded image, shared with the other shapes given the same file."""
 
     pixbuf_loaded: bool = False
     """Whether loading the image has been attempted, successfully or not."""

--- a/bbb_presentation_video/renderer/tldraw/shape/__init__.py
+++ b/bbb_presentation_video/renderer/tldraw/shape/__init__.py
@@ -4,7 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import attr
 import cairo
@@ -20,6 +30,9 @@ from bbb_presentation_video.renderer.tldraw.utils import (
     SplineType,
     Style,
 )
+
+if TYPE_CHECKING:
+    from gi.repository import GdkPixbuf
 
 BaseShapeSelf = TypeVar("BaseShapeSelf", bound="BaseShapeProto")
 
@@ -247,6 +260,32 @@ class HighlighterShape(RotatableShapeProto):
             self.isComplete = data["isComplete"]
         elif "props" in data and "isComplete" in data["props"]:
             self.isComplete = data["props"]["isComplete"]
+
+
+@attr.s(order=False, slots=True, auto_attribs=True)
+class ImageShape(RotatableShapeProto):
+    src: Optional[str] = None
+    """Location of the image, as recorded by the whiteboard client."""
+
+    pixbuf: Optional[GdkPixbuf.Pixbuf] = None
+    """The decoded image, cached after the first render."""
+
+    pixbuf_loaded: bool = False
+    """Whether loading the image has been attempted, successfully or not."""
+
+    # SizedShapeProto
+    size: Size = Size(1.0, 1.0)
+
+    def update_from_data(self, data: ShapeData) -> None:
+        super().update_from_data(data)
+
+        if "meta" in data and "bbbImageSrc" in data["meta"]:
+            src = data["meta"]["bbbImageSrc"]
+            # Moving or resizing a shape must not discard the decoded image
+            if src != self.src:
+                self.src = src
+                self.pixbuf = None
+                self.pixbuf_loaded = False
 
 
 @attr.s(order=False, slots=True, auto_attribs=True)
@@ -649,6 +688,7 @@ Shape = Union[
     GroupShape,
     HexagonGeoShape,
     HighlighterShape,
+    ImageShape,
     LineShape,
     OvalGeoShape,
     RectangleGeoShape,
@@ -703,6 +743,8 @@ def parse_shape_from_data(data: ShapeData, bbb_version: Version) -> Optional[Sha
         return FrameShape.from_data(data)
     elif type == "poll":
         return PollShape.from_data(data)
+    elif type == "image":
+        return ImageShape.from_data(data)
     elif type == "geo":
         if "geo" in data["props"]:
             geo_type = GeoShape(data["props"]["geo"])

--- a/bbb_presentation_video/renderer/tldraw/v2/shape/image.py
+++ b/bbb_presentation_video/renderer/tldraw/v2/shape/image.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2026 BigBlueButton Inc. and by respective authors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from os import path
+from typing import Optional, TypeVar
+
+import cairo
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+gi.require_version("GLib", "2.0")
+
+from gi.repository import Gdk, GdkPixbuf, GLib
+
+from bbb_presentation_video.renderer.tldraw.shape import ImageShape
+
+CairoSomeSurface = TypeVar("CairoSomeSurface", bound=cairo.Surface)
+
+IMAGE_EXTENSIONS = frozenset(("gif", "jpeg", "jpg", "png", "webp"))
+"""Image types that can be pasted onto the whiteboard, matching the allowlist
+used by bbb-export-annotations."""
+
+
+def upload_filename(src: str) -> Optional[str]:
+    """Resolve an image source to a file name within the uploads directory.
+
+    Only the base name is kept, so a source crafted by a presenter cannot
+    escape the uploads directory, and the extension has to be one that the
+    whiteboard accepts.
+    """
+    filename = path.basename(src)
+    extension = path.splitext(filename)[1][1:].lower()
+    if extension not in IMAGE_EXTENSIONS:
+        return None
+    return filename
+
+
+def load_pixbuf(shape: ImageShape, directory: str) -> Optional[GdkPixbuf.Pixbuf]:
+    """Load the image belonging to a shape, caching the result on the shape.
+
+    Recordings made before pasted images were archived have no uploads
+    directory, so an image that cannot be read is reported and skipped instead
+    of interrupting the rendering.
+    """
+    if shape.pixbuf_loaded:
+        return shape.pixbuf
+    shape.pixbuf_loaded = True
+
+    if shape.src is None:
+        return None
+
+    filename = upload_filename(shape.src)
+    if filename is None:
+        print(f"\tTldraw: image has an unsupported source: {shape.src}")
+        return None
+
+    filepath = path.join(directory, "uploads", filename)
+    try:
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(filepath)
+    except GLib.Error as error:
+        print(f"\tTldraw: failed to read image {filepath}: {error}")
+        return None
+
+    if pixbuf.get_width() <= 0 or pixbuf.get_height() <= 0:
+        print(f"\tTldraw: ignoring empty image {filepath}")
+        return None
+
+    shape.pixbuf = pixbuf
+    return pixbuf
+
+
+def finalize_image(
+    ctx: cairo.Context[CairoSomeSurface],
+    id: str,
+    shape: ImageShape,
+    directory: str,
+) -> None:
+    print(f"\tTldraw: Finalizing Image: {id}")
+
+    pixbuf = load_pixbuf(shape, directory)
+    if pixbuf is None:
+        return
+
+    if shape.size.width <= 0 or shape.size.height <= 0:
+        print(f"\tTldraw: ignoring image with a degenerate size: {id}")
+        return
+
+    style = shape.style
+
+    ctx.rotate(shape.rotation)
+
+    ctx.push_group()
+
+    # Draw at the image's own resolution and let cairo scale it to the size the
+    # shape was given, so that zooming in does not resample twice.
+    ctx.save()
+    ctx.scale(
+        shape.size.width / pixbuf.get_width(),
+        shape.size.height / pixbuf.get_height(),
+    )
+    Gdk.cairo_set_source_pixbuf(ctx, pixbuf, 0, 0)
+    ctx.rectangle(0, 0, pixbuf.get_width(), pixbuf.get_height())
+    ctx.fill()
+    ctx.restore()
+
+    ctx.pop_group_to_source()
+    ctx.paint_with_alpha(style.opacity)

--- a/bbb_presentation_video/renderer/tldraw/v2/shape/image.py
+++ b/bbb_presentation_video/renderer/tldraw/v2/shape/image.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from os import path
-from typing import Optional, TypeVar
+from typing import Dict, Optional, TypeVar
 
 import cairo
 import gi
@@ -20,17 +20,39 @@ from bbb_presentation_video.renderer.tldraw.shape import ImageShape
 
 CairoSomeSurface = TypeVar("CairoSomeSurface", bound=cairo.Surface)
 
-IMAGE_EXTENSIONS = frozenset(("gif", "jpeg", "jpg", "png", "webp"))
-"""Image types that can be pasted onto the whiteboard, matching the allowlist
-used by bbb-export-annotations."""
+IMAGE_EXTENSIONS = frozenset(("gif", "jpeg", "jpg", "png"))
+"""Image types that can be pasted onto the whiteboard and that this renderer can
+decode.
+
+The whiteboard also accepts webp, but gdk-pixbuf carries no webp loader and the
+package does not depend on one, so a pasted webp is reported and left undrawn
+rather than failing halfway through a recording.
+"""
+
+MAX_IMAGE_PIXELS = 4096 * 4096
+"""Largest image that is worth decoding, in pixels.
+
+A file small enough to be archived can declare enormous dimensions, and decoding
+costs four bytes per pixel however small the file was, so the dimensions are read
+from the header and checked before the image itself is read.
+"""
+
+_PIXBUF_CACHE: Dict[str, Optional[GdkPixbuf.Pixbuf]] = {}
+"""Images already read, keyed by the file they came from.
+
+A presenter can paste the same upload onto many slides, and the decoded image is
+much larger than the file, so every shape naming a given file shares a single
+decoded copy. A file that could not be read is remembered as well, so it is not
+retried once per shape.
+"""
 
 
 def upload_filename(src: str) -> Optional[str]:
     """Resolve an image source to a file name within the uploads directory.
 
     Only the base name is kept, so a source crafted by a presenter cannot
-    escape the uploads directory, and the extension has to be one that the
-    whiteboard accepts.
+    escape the uploads directory, and the extension has to be one this renderer
+    can decode.
     """
     filename = path.basename(src)
     extension = path.splitext(filename)[1][1:].lower()
@@ -39,13 +61,34 @@ def upload_filename(src: str) -> Optional[str]:
     return filename
 
 
-def load_pixbuf(shape: ImageShape, directory: str) -> Optional[GdkPixbuf.Pixbuf]:
-    """Load the image belonging to a shape, caching the result on the shape.
+def read_pixbuf(filepath: str) -> Optional[GdkPixbuf.Pixbuf]:
+    """Read an image from the uploads directory.
 
     Recordings made before pasted images were archived have no uploads
     directory, so an image that cannot be read is reported and skipped instead
     of interrupting the rendering.
     """
+    _, width, height = GdkPixbuf.Pixbuf.get_file_info(filepath)
+    if width * height > MAX_IMAGE_PIXELS:
+        print(f"\tTldraw: skipping image with excessive dimensions: {filepath}")
+        return None
+
+    try:
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file(filepath)
+    except GLib.Error as error:
+        print(f"\tTldraw: failed to read image {filepath}: {error}")
+        return None
+
+    if pixbuf.get_width() <= 0 or pixbuf.get_height() <= 0:
+        print(f"\tTldraw: ignoring empty image {filepath}")
+        return None
+
+    return pixbuf
+
+
+def load_pixbuf(shape: ImageShape, directory: str) -> Optional[GdkPixbuf.Pixbuf]:
+    """Load the image belonging to a shape, sharing it with the other shapes
+    that were given the same file."""
     if shape.pixbuf_loaded:
         return shape.pixbuf
     shape.pixbuf_loaded = True
@@ -59,18 +102,11 @@ def load_pixbuf(shape: ImageShape, directory: str) -> Optional[GdkPixbuf.Pixbuf]
         return None
 
     filepath = path.join(directory, "uploads", filename)
-    try:
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file(filepath)
-    except GLib.Error as error:
-        print(f"\tTldraw: failed to read image {filepath}: {error}")
-        return None
+    if filepath not in _PIXBUF_CACHE:
+        _PIXBUF_CACHE[filepath] = read_pixbuf(filepath)
 
-    if pixbuf.get_width() <= 0 or pixbuf.get_height() <= 0:
-        print(f"\tTldraw: ignoring empty image {filepath}")
-        return None
-
-    shape.pixbuf = pixbuf
-    return pixbuf
+    shape.pixbuf = _PIXBUF_CACHE[filepath]
+    return shape.pixbuf
 
 
 def finalize_image(

--- a/tests/renderer/tldraw/test_shape.py
+++ b/tests/renderer/tldraw/test_shape.py
@@ -4,6 +4,7 @@ from bbb_presentation_video.renderer.tldraw.shape import (
     ArrowShape,
     DrawShape,
     HighlighterShape,
+    ImageShape,
     LineShape,
 )
 from bbb_presentation_video.renderer.tldraw.utils import (
@@ -295,3 +296,39 @@ def test_highlight_from_data() -> None:
 
     assert highlight.point == Position(354, 140)
     assert highlight.rotation == 0
+
+
+def test_image_from_data() -> None:
+    data: ShapeData = {
+        "x": 519.9955039238482,
+        "isLocked": False,
+        "y": 254.99172313253888,
+        "rotation": 0,
+        "typeName": "shape",
+        "isModerator": True,
+        "opacity": 1,
+        "parentId": "page:4",
+        "index": "a1",
+        "id": "shape:iOJgFnCJFdyC0-Hk0mp77",
+        "meta": {
+            "bbbImageSrc": "/bigbluebutton/fileUpload/986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863/44c71706-8566-4c79-a303-79f6862affb0.png",
+            "createdBy": "w_scve2tey3vli",
+        },
+        "type": "image",
+        "props": {
+            "w": 400,
+            "h": 300,
+        },
+    }
+
+    image = ImageShape.from_data(data)
+
+    assert (
+        image.src
+        == "/bigbluebutton/fileUpload/986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863/44c71706-8566-4c79-a303-79f6862affb0.png"
+    )
+    assert image.size == Size(400, 300)
+    assert image.point == Position(519.9955039238482, 254.99172313253888)
+    assert image.rotation == 0
+    assert image.pixbuf is None
+    assert image.pixbuf_loaded == False

--- a/tests/renderer/tldraw/v2/shape/test_image.py
+++ b/tests/renderer/tldraw/v2/shape/test_image.py
@@ -1,3 +1,4 @@
+import struct
 from pathlib import Path
 
 import cairo
@@ -85,6 +86,33 @@ def test_finalize_image_with_a_size(tmp_path: Path) -> None:
 
     # The image really was readable, so the skip above was the size check
     assert shape.pixbuf is not None
+
+
+def test_finalize_image_draws_for_every_shape_sharing_the_image(tmp_path: Path) -> None:
+    """A shared decoded image has to draw for the second shape as much as the first."""
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    upload = cairo.ImageSurface(cairo.FORMAT_ARGB32, 2, 2)
+    painter = cairo.Context(upload)
+    painter.set_source_rgb(1, 0, 0)
+    painter.paint()
+    upload.write_to_png(str(uploads / "44c71706.png"))
+
+    for _ in range(2):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10)
+        finalize_image(
+            cairo.Context(surface),
+            "shape:test",
+            image_shape(Size(10, 10)),
+            str(tmp_path),
+        )
+        surface.flush()
+
+        # Away from the edges, where scaling a two pixel image blends towards
+        # transparent. Cairo keeps ARGB32 as native byte order, premultiplied.
+        centre = 5 * surface.get_stride() + 5 * 4
+        (pixel,) = struct.unpack_from("=I", bytes(surface.get_data()), centre)
+        assert pixel == 0xFFFF0000, "expected opaque red"
 
 
 def test_shapes_sharing_a_file_share_one_decoded_image(tmp_path: Path) -> None:

--- a/tests/renderer/tldraw/v2/shape/test_image.py
+++ b/tests/renderer/tldraw/v2/shape/test_image.py
@@ -5,6 +5,7 @@ import cairo
 from bbb_presentation_video.events.helpers import Size
 from bbb_presentation_video.renderer.tldraw.shape import ImageShape
 from bbb_presentation_video.renderer.tldraw.v2.shape.image import (
+    MAX_IMAGE_PIXELS,
     finalize_image,
     load_pixbuf,
     upload_filename,
@@ -12,7 +13,7 @@ from bbb_presentation_video.renderer.tldraw.v2.shape.image import (
 
 
 def test_upload_filename_accepts_supported_types() -> None:
-    for extension in ["png", "PNG", "jpg", "jpeg", "gif", "webp"]:
+    for extension in ["png", "PNG", "jpg", "jpeg", "gif"]:
         src = f"/bigbluebutton/fileUpload/meeting-id/44c71706.{extension}"
         assert upload_filename(src) == f"44c71706.{extension}"
 
@@ -21,6 +22,11 @@ def test_upload_filename_rejects_unsupported_types() -> None:
     assert upload_filename("/bigbluebutton/fileUpload/meeting-id/44c71706.svg") is None
     assert upload_filename("/bigbluebutton/fileUpload/meeting-id/44c71706") is None
     assert upload_filename("") is None
+
+
+def test_upload_filename_rejects_webp() -> None:
+    """There is no webp loader to decode it with, so it is not accepted."""
+    assert upload_filename("/bigbluebutton/fileUpload/meeting-id/44c71706.webp") is None
 
 
 def test_upload_filename_strips_directories() -> None:
@@ -79,3 +85,32 @@ def test_finalize_image_with_a_size(tmp_path: Path) -> None:
 
     # The image really was readable, so the skip above was the size check
     assert shape.pixbuf is not None
+
+
+def test_shapes_sharing_a_file_share_one_decoded_image(tmp_path: Path) -> None:
+    """Pasting the same upload many times must not decode it many times."""
+    write_upload(tmp_path)
+
+    first = load_pixbuf(image_shape(Size(4, 3)), str(tmp_path))
+    second = load_pixbuf(image_shape(Size(9, 9)), str(tmp_path))
+
+    assert first is not None
+    assert first is second
+
+
+def test_load_pixbuf_with_excessive_dimensions(tmp_path: Path) -> None:
+    """A file small enough to archive can still decode to gigabytes."""
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    # Written rather than committed, since the repository keeps no binary
+    # fixtures. Just over the limit, so a missing check would decode it.
+    side = 4097
+    assert side * side > MAX_IMAGE_PIXELS
+    cairo.ImageSurface(cairo.FORMAT_ARGB32, side, side).write_to_png(
+        str(uploads / "44c71706.png")
+    )
+
+    shape = image_shape(Size(4, 3))
+
+    assert load_pixbuf(shape, str(tmp_path)) is None
+    assert shape.pixbuf is None

--- a/tests/renderer/tldraw/v2/shape/test_image.py
+++ b/tests/renderer/tldraw/v2/shape/test_image.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+import cairo
+
+from bbb_presentation_video.events.helpers import Size
+from bbb_presentation_video.renderer.tldraw.shape import ImageShape
+from bbb_presentation_video.renderer.tldraw.v2.shape.image import (
+    finalize_image,
+    load_pixbuf,
+    upload_filename,
+)
+
+
+def test_upload_filename_accepts_supported_types() -> None:
+    for extension in ["png", "PNG", "jpg", "jpeg", "gif", "webp"]:
+        src = f"/bigbluebutton/fileUpload/meeting-id/44c71706.{extension}"
+        assert upload_filename(src) == f"44c71706.{extension}"
+
+
+def test_upload_filename_rejects_unsupported_types() -> None:
+    assert upload_filename("/bigbluebutton/fileUpload/meeting-id/44c71706.svg") is None
+    assert upload_filename("/bigbluebutton/fileUpload/meeting-id/44c71706") is None
+    assert upload_filename("") is None
+
+
+def test_upload_filename_strips_directories() -> None:
+    """A source can only ever name a file directly inside the uploads directory."""
+    assert upload_filename("../../../etc/shadow.png") == "shadow.png"
+    assert upload_filename("/etc/ssl/private/server.png") == "server.png"
+    assert upload_filename("../../../etc/shadow") is None
+
+
+def test_load_pixbuf_without_uploads_directory(tmp_path: Path) -> None:
+    """Recordings made before pasted images were archived still have to render."""
+    shape = ImageShape()
+    shape.src = "/bigbluebutton/fileUpload/meeting-id/44c71706.png"
+
+    assert load_pixbuf(shape, str(tmp_path)) is None
+    assert shape.pixbuf is None
+
+    # The failure is remembered, so re-rendering does not retry the missing file
+    assert shape.pixbuf_loaded == True
+
+
+def test_load_pixbuf_without_source(tmp_path: Path) -> None:
+    assert load_pixbuf(ImageShape(), str(tmp_path)) is None
+
+
+def write_upload(directory: Path) -> None:
+    """Put a readable one pixel image where an archived upload would be."""
+    uploads = directory / "uploads"
+    uploads.mkdir()
+    cairo.ImageSurface(cairo.FORMAT_ARGB32, 1, 1).write_to_png(
+        str(uploads / "44c71706.png")
+    )
+
+
+def image_shape(size: Size) -> ImageShape:
+    shape = ImageShape()
+    shape.src = "/bigbluebutton/fileUpload/meeting-id/44c71706.png"
+    shape.size = size
+    return shape
+
+
+def test_finalize_image_with_degenerate_size(tmp_path: Path) -> None:
+    """A shape whose size never got set must be skipped, not crash the render."""
+    write_upload(tmp_path)
+    ctx = cairo.Context(cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10))
+
+    finalize_image(ctx, "shape:test", image_shape(Size(0, 0)), str(tmp_path))
+
+
+def test_finalize_image_with_a_size(tmp_path: Path) -> None:
+    write_upload(tmp_path)
+    ctx = cairo.Context(cairo.ImageSurface(cairo.FORMAT_ARGB32, 10, 10))
+    shape = image_shape(Size(4, 3))
+
+    finalize_image(ctx, "shape:test", shape, str(tmp_path))
+
+    # The image really was readable, so the skip above was the size check
+    assert shape.pixbuf is not None

--- a/typings/gi/repository/GdkPixbuf.pyi
+++ b/typings/gi/repository/GdkPixbuf.pyi
@@ -2,10 +2,16 @@
 #
 # SPDX-License-Identifier: LGPL-2.0-or-later
 
-from typing import Union
+from typing import Optional, Tuple, Union
+
+class PixbufFormat: ...
 
 class Pixbuf:
     @classmethod
     def new_from_file(cls, filename: Union[str, bytes]) -> Pixbuf: ...
+    @classmethod
+    def get_file_info(
+        cls, filename: Union[str, bytes]
+    ) -> Tuple[Optional[PixbufFormat], int, int]: ...
     def get_height(self) -> int: ...
     def get_width(self) -> int: ...


### PR DESCRIPTION
## What changed

Draw tldraw `image` shapes instead of discarding them.

The renderer now:

- parses `image` shapes into an `ImageShape` carrying the upload named by `meta.bbbImageSrc`;
- loads that file from the recording's `uploads/` directory and draws it at the shape's size, rotation and opacity;
- keeps the decoded image, so panning or zooming does not decode it again, and shares one copy between every shape naming the same file, so pasting one upload twelve times costs one decode rather than twelve;
- keeps only the base name of the source and requires an extension it can decode (png, jpg, jpeg, gif), so a source cannot reach a file outside `uploads/`;
- reads the dimensions from the file header and skips an image beyond 4096x4096 pixels before decoding it, so a small file declaring enormous dimensions cannot exhaust the memory of an unattended render;
- reports and skips an image it cannot read, instead of interrupting the render.

## Why

`add_shape_event` returned early on `data["type"] == "image"`, before the shape was ever parsed, so an image a presenter pasted onto the whiteboard was missing from the video recording while every other annotation on the same slide was drawn. The archive step of https://github.com/bigbluebutton/bigbluebutton/pull/25385 already copies the pasted files into the recording, so the bytes were sitting next to the renderer unused.

The shape's `props.assetId` points at a tldraw asset record that is not present in `events.xml`, so `meta.bbbImageSrc` is the only usable source. This is the same conclusion `bbb-export-annotations/shapes/Image.js` reached, and this change reuses its contract: base name plus extension allowlist, and a missing file draws nothing. The allowlist here leaves out webp, for the decoder reason given under the limitations below.

## Known limitations

- Cropped and flipped images are drawn uncropped and unflipped.
- An image that exists only at a remote `props.url`, with no archived upload, is not drawn.
- A pasted webp image is not rendered in the video format. The whiteboard accepts webp, but gdk-pixbuf carries no webp loader and this package does not depend on one, so webp is left out of the allowlist and reported instead of reaching a decoder that cannot read it. Declaring the loader is an install time dependency and belongs to the packaging layer, not here. The presentation format, which renders in a browser, is unaffected.
- An image larger than 4096x4096 pixels is not drawn, since the renderer refuses to decode it.

The first two match the scope `bbb-export-annotations` covers today. None of the four is scheduled work.

## Tests

- `black --check` on the changed files: clean.
- `mypy`: clean, no issues in 48 source files.
- `pytest`: 19 passed, including the new `ImageShape` parse test and tests covering the extension allowlist, the webp rejection, directory stripping, the missing-uploads path, the degenerate-size skip that keeps a zero-size shape from aborting the render, two shapes sharing one decoded image, that shared image still drawing for the second shape (read back from the surface, not just called), and an oversized image being refused.
- `black --check .` on the whole repository reports 7 pre-existing reformats, in `typings/*.pyi`, `events/helpers.py`, `renderer/whiteboard.py`, `renderer/tldraw/utils.py` and `renderer/tldraw/shape/poll.py`. None is a file this change touches, and the count is identical with and without it (measured on both). `black` is unpinned in `requirements-dev.txt`, so the exact count moves with the released version.
- The sharing and the size bound were measured, not just asserted: twelve shapes naming one 15KB upload cost 184MB before and 16MB after, and a 63KB file declaring 4097x4097 pixels is now refused after allocating 1MB, so it is never decoded.
- Rendered end to end against BBB 4.0 from-source, and a recording with its uploads directory removed still renders with no error. Verified in a desktop browser against the video recording format; other recording formats and mobile layouts were not checked.

## Evidence

Recording: `986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863`

- Before: the pasted image is absent from the whiteboard slide in the rendered video.
- After: the `PASTE-IMG 25385` image renders at its position on the whiteboard.
- Full pipeline: `bbb-record --rebuild` republished `video-0.m4v`; the before and after videos differ only across the window where the image is on screen.
- Pasted image appears on the whiteboard - 00:09 in the clip.

Before:

![Before: the pasted image is missing from the whiteboard](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/7a2125b1-47a2-4e1d-91a9-e93cd2b2c4f9/video-format-before.png)

After:

![After: the pasted image renders on the whiteboard](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/8930fefd-518d-4289-a1e7-3a2176ef9349/video-format-after.png)

Animated preview below - click the GIF to open the MP4 with playback controls:

[![Video format: the pasted image renders on the whiteboard](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/c37632f1-ee98-418b-aa06-4ee6989466f3/image-shape-video-format.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/d60cb1e1-161d-4277-b4a3-c7f1b17d1d72/image-shape-video-format.mp4)
